### PR TITLE
Fix resource loading path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/eutopia-platform/members-platform-frontend#readme",
   "scripts": {
     "start": "parcel src/index.html --no-autoinstall",
-    "build": "parcel build --no-source-maps --public-url . src/index.html",
+    "build": "parcel build --no-source-maps src/index.html",
     "now-build": "npm run build",
     "format:check": "prettier --check \"./*.{js,vue,html}\" \"./**/*.{js,vue,html}\"",
     "format:write": "prettier --write \"./*.{js,vue,html}\" \"./**/*.{js,vue,html}\"",


### PR DESCRIPTION
With `--public-url .` parcel was loading resources relative to the current (url) directory, which in the build doesn't work for paths like `/space/foo/` after reloading the page.
The default for `--public-url` is `/` so by removing the param the resources are now correctly loaded from the root directory.